### PR TITLE
fix param parse when param has no value

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,6 +136,9 @@ func ParseMultiple(headers []string) Links {
 func parseParam(raw string) (key, val string) {
 
 	parts := strings.SplitN(raw, "=", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
 	if len(parts) != 2 {
 		return "", ""
 	}


### PR DESCRIPTION
defination: [rfc5988](https://tools.ietf.org/html/rfc5988#section-5) - link-extension