### PR TITLE
Reintroduce CI, add Go modules support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Lint
 
 on:
   push:
@@ -11,19 +11,17 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.13', '1.21' ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '1.21'
         check-latest: true
-    - name: Build
-      run: go build -v ./...
-    - name: Test
-      run: go test -v ./...
+        cache: false
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.54

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.13', '1.21' ]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go }}
+        check-latest: true
+    - name: Build
+      run: go build -v ./...
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.54
+    - name: Test
+      run: go test -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: go
-
-go:
-  - 1.6
-  - 1.7
-  - tip

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tomnomnom/linkheader
+
+go 1.13

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,6 +1,5 @@
 #!/bin/sh
 PROJDIR=$(cd `dirname $0`/.. && pwd)
 
-echo "Installing gometalinter and linters..."
-go get github.com/alecthomas/gometalinter
-gometalinter --install
+echo "Installing golangci-lint linter..."
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1

--- a/script/lint
+++ b/script/lint
@@ -2,5 +2,4 @@
 PROJDIR=$(cd `dirname $0`/.. && pwd)
 
 cd ${PROJDIR}
-go get
-gometalinter
+golangci-lint run


### PR DESCRIPTION
Hiya! I've started using this library in a project so figured I'd send a small PR to fix a few things:

* Add a go.mod
* Update to using a current and supported linter
* Move tests run on GitHub Actions as the Travis setup seems dead